### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Send mail via mailgun",
   "main": "index.js",
   "dependencies": {
-    "mailgun": "~0.4.2"
+    "mailgun": "~0.5.0"
   },
   "devDependencies": {
     "mocha": "~1.19.0",


### PR DESCRIPTION
Mailgun ~0.4 not sending emails now. It uses deprecated api call and always gets 403.